### PR TITLE
Remove non-project related gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
 analysis.json
 analysis.out
 all_tests.bats
-
-# vim
-.*.sw?
-.sw?


### PR DESCRIPTION
Artifacts that are created due to personal choices should not be in the
projects gitignore, but rather maintained personally.
