### PR TITLE
[shellcheck] Disable SC2190

### DIFF
--- a/lib/shellcheck/analysis.bash
+++ b/lib/shellcheck/analysis.bash
@@ -12,6 +12,7 @@ analyze() {
         "--check-sourced"
         "--norc"
         "--format=json1"
+        "--exclude=SC2190" # Temporarily disable: https://github.com/koalaman/shellcheck/issues/2393
     )
     (
         cd "$in_dir" > /dev/null || exit 1


### PR DESCRIPTION
Automated feedback on associative arrays appears incorrect.
See: https://github.com/koalaman/shellcheck/issues/2393